### PR TITLE
Fix conversion of numbers with decimals

### DIFF
--- a/app/src/main/java/com/mayokunadeniyi/instantweather/utils/Utils.kt
+++ b/app/src/main/java/com/mayokunadeniyi/instantweather/utils/Utils.kt
@@ -5,18 +5,23 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import java.text.DecimalFormat
 
 /**
  * Created by Mayokun Adeniyi on 30/03/2020.
  */
 
 /**
- * This function converts a [number] from Kelvin to Celsius by converting it to
- * a [Double] then subtracting 273 from it.
+ * This function converts a [number] from Kelvin to Celsius by using [DecimalFormat] and
+ * converting it to a [Double] then subtracting 273 from it.
  * @param number the number to be converted to Celsius.
  */
 fun convertKelvinToCelsius(number: Number): Double {
-    return "%.2f".format(number.toDouble().minus(273)).toDouble()
+    return DecimalFormat.getInstance().run {
+        this as DecimalFormat
+        applyPattern(".##")
+        parse(format(number.toDouble().minus(273))) as Double
+    }
 }
 
 /**


### PR DESCRIPTION
Converting String to Number directly, may cause a problem. [format](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/format.html) uses default locale value to format. However, [toDouble](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/to-double.html) is unaware of what locale is. [format](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/format.html)  might be return a separator with dot or comma depends on locale, explained [here](https://en.wikipedia.org/wiki/Decimal_separator). If those do not match, it causes a crash. To reproduce the crash, e.g. Locale.FRANCE can be given as a parameter to  [format](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/format.html). So I think [DecimalFormat](https://developer.android.com/reference/java/text/DecimalFormat) should be used for the conversion.

Also congratulations for this great work and thanks for sharing!