### PR TITLE
Simplfied the utils method to convert weather temperature

### DIFF
--- a/app/src/main/java/com/mayokunadeniyi/instantweather/utils/Utils.kt
+++ b/app/src/main/java/com/mayokunadeniyi/instantweather/utils/Utils.kt
@@ -17,10 +17,9 @@ import java.text.DecimalFormat
  * @param number the number to be converted to Celsius.
  */
 fun convertKelvinToCelsius(number: Number): Double {
-    return DecimalFormat.getInstance().run {
-        this as DecimalFormat
+    return DecimalFormat().run {
         applyPattern(".##")
-        parse(format(number.toDouble().minus(273))) as Double
+        parse(format(number.toDouble().minus(273))).toDouble()
     }
 }
 


### PR DESCRIPTION
Made some changes to the utils method that converts the temperature from kelvin to Celsuis
* Rather than using the factory to create a number format. We can use the constructor to create the DecimaFormat and would save us from casting it.
* Using the `toDouble()` instead of explicit casting with `as`